### PR TITLE
Make CategoryLink play nicely with other pages

### DIFF
--- a/categorylink/models.py
+++ b/categorylink/models.py
@@ -25,13 +25,7 @@ class CategoryLink(pages_models.Page):
         # not the hybrid animal
         cat_slug = self.blog_category.slug
 
-        # know we are like /.../ which breaks later get_absolute_url calls
         rev_url = reverse('blog_post_list_category', args=(cat_slug,))
-        if rev_url[0] == '/':
-            rev_url = rev_url[1:]
-        if rev_url[-1] == '/':
-            rev_url = rev_url[:-1]
-
         return rev_url
 
     def save(self, *args, **kwargs):

--- a/categorylink/models.py
+++ b/categorylink/models.py
@@ -3,11 +3,13 @@
 from django.core.urlresolvers import reverse
 
 from django.utils.translation import ugettext_lazy as _
+from django.utils.http import urlunquote
 
 from django.db import models
 
 from mezzanine.blog import models as blog_models
 from mezzanine.pages import models as pages_models
+
 
 class CategoryLink(pages_models.Page):
     """Link to blog category
@@ -33,8 +35,8 @@ class CategoryLink(pages_models.Page):
         return rev_url
 
     def save(self, *args, **kwargs):
-        self.slug = self.get_absolute_url()
+        slug = urlunquote(self.get_absolute_url())
+        self.slug = '/%s/' % slug.strip('/')
         return super(CategoryLink, self).save(*args, **kwargs)
 
 # EOF
-

--- a/categorylink/models.py
+++ b/categorylink/models.py
@@ -26,11 +26,10 @@ class CategoryLink(pages_models.Page):
         cat_slug = self.blog_category.slug
 
         rev_url = reverse('blog_post_list_category', args=(cat_slug,))
-        return rev_url
+        return rev_url.strip('/')
 
     def save(self, *args, **kwargs):
-        slug = urlunquote(self.get_absolute_url())
-        self.slug = '/%s/' % slug.strip('/')
+        self.slug = urlunquote(self.get_absolute_url())
         return super(CategoryLink, self).save(*args, **kwargs)
 
 # EOF


### PR DESCRIPTION
Django's `reverse` automatically escapes URLs, so when we get CategoryLink's slug from `get_absolute_url` (which in turn uses `reverse`) we get an escaped URL, while Mezzanine basically uses unescaped URLs everywhere. This becomes a problem when you try to compare slugs with each other, like when using the `is_current_or_ascendant` method.

I add an extra `unquote` call to convert the slug back as unescaped so that it is absolutely compatible with other slugs in Mezzanine. I also changed the `if slug[0] == '/'` things to use `strip` instead, but that's doesn't really affect anything.
